### PR TITLE
Additional text for references

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Then, when you want to cite the reference to `The Late War` in the bib file, use
 {{ "TLW" | cite }}
 ```
 
+The referenced pages or any other additional information may be used as a string passed to the `cite` filter:
+
+```
+{{ "TLW" | cite("p. 121") }}
+```
+
 You can also add a table of references with:
 
 ```

--- a/README.md
+++ b/README.md
@@ -44,8 +44,13 @@ Then, when you want to cite the reference to `The Late War` in the bib file, use
 The referenced pages or any other additional information may be used as a string passed to the `cite` filter:
 
 ```
-{{ "TLW" | cite("p. 121") }}
+{{ "TLW" | cite("p.~121") }}
 ```
+
+The argument, "p. 211", will show up inside the same brackets. 
+Note the tilde in [p.~211], which replaces the end-of-sentence spacing with a non-breakable inter-word space.
+This non-breakable inter-word space is inserted because the end-of-sentence spacing would be too wide,
+and "p." should not be separated from the page number.
 
 You can also add a table of references with:
 

--- a/index.js
+++ b/index.js
@@ -19,9 +19,10 @@ module.exports = {
                     this.config.set('bibCount', this.config.get('bibCount') + 1);
                     citation.number = this.config.get('bibCount');
                 }
-                var citationText = citation.number
+                var citationText = citation.number;
                 if (additionalText) {
-                    citationText += ", " + additionalText
+                    additionalText = additionalText.replace(/~/g, "&nbsp;");
+                    citationText += ", " + additionalText;
                 }
                 return '<a href="#cite-' + citation.number + '">[' + citationText + ']</a>';
             } else {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     },
 
     filters: {
-        cite: function(key) {
+        cite: function(key, additionalText) {
             var citation = _.find(this.config.get('bib'), {'citationKey': key.toUpperCase()});
             if (citation !== undefined) {
                 if (!citation.used) {
@@ -19,7 +19,11 @@ module.exports = {
                     this.config.set('bibCount', this.config.get('bibCount') + 1);
                     citation.number = this.config.get('bibCount');
                 }
-                return '<a href="#cite-' + citation.number + '">[' + citation.number + ']</a>';
+                var citationText = citation.number
+                if (additionalText) {
+                    citationText += ", " + additionalText
+                }
+                return '<a href="#cite-' + citation.number + '">[' + citationText + ']</a>';
             } else {
                 return "[Citation not found]";
             }


### PR DESCRIPTION
Hi! The LaTeX version of the `cite` command allows to provide [additional text](https://en.wikibooks.org/wiki/LaTeX/Bibliography_Management#Referring_more_specifically) inserted inside the square brackets. This pull request is intended to add the same functionality to the plugin.